### PR TITLE
added dcterms:modified to all terms

### DIFF
--- a/sc4eu_vo.ttl
+++ b/sc4eu_vo.ttl
@@ -10,186 +10,214 @@
     rdfs:label "Past Demand";
     dcterms:description "Demand with a delivery date in the past";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-26T13:51:27.062Z"^^xsd:dateTime.
 <https://example.com#74eaf886-7525-490e-a9a2-cb3bc28c6b54> rdf:type rdfs:Resource;
     dcterms:identifier "74eaf886-7525-490e-a9a2-cb3bc28c6b54";
     rdfs:label "Future Demand";
     skos:altLabel "Forecast";
     dcterms:description "Sales / Marketing Forecast. Unconstrained customer demand not taking into account the companies capacity. Already adjusted based on multiple business indicators such as orders on hand, historic sales, order backlog, customer information, cycle management and other macro-economic indicators";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-26T13:53:21.238Z"^^xsd:dateTime.
 <https://example.com#8abc6005-c0c0-4c35-869a-77b75750aa48> rdf:type rdfs:Resource;
     dcterms:identifier "8abc6005-c0c0-4c35-869a-77b75750aa48";
     rdfs:label "Sales and Marketing Forecast ";
     skos:altLabel "Unconstrained demand";
     dcterms:description "(Expectation of what a company thinks they would be able to sell) based on orders, past billings and more";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#07ecb673-52a9-4415-8b08-9c59690c29d0> rdf:type rdfs:Resource;
     dcterms:identifier "07ecb673-52a9-4415-8b08-9c59690c29d0";
     rdfs:label "Inventory Reach";
     dcterms:description "Inventory reach is a measure of how long a company‘s current inventory will last under normal sales conditions.";
     rdfs:seeAlso "Inventory Coverage, Days of Inventory";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-26T14:01:20.858Z"^^xsd:dateTime.
 <https://example.com#ac8ec0bb-4558-4b19-81b0-c848f4a048fb> rdf:type rdfs:Resource;
     dcterms:identifier "ac8ec0bb-4558-4b19-81b0-c848f4a048fb";
     rdfs:label "True Demand";
     dcterms:description "True Demand is the incoming demand at the semiconductor manufacturer, without deliberate, conscious behavioral distortions such as shortage gaming, speculative inventory buildup and the effects of independent forecast updating.\"";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:58:46.180Z"^^xsd:dateTime.
 <https://example.com#a601e751-d6a2-472b-92d6-c33d16b4aa8e> rdf:type rdfs:Resource;
     dcterms:identifier "a601e751-d6a2-472b-92d6-c33d16b4aa8e";
     rdfs:label "Stock Depth";
     skos:altLabel "SD";
     dcterms:description "The sum of Desired Inventory Coverage of all the tiers between a company and its End Market. It is measured in time units.";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#f47de173-cd8e-48c7-8d39-906648d3aef2> rdf:type rdfs:Resource;
     dcterms:identifier "f47de173-cd8e-48c7-8d39-906648d3aef2";
     rdfs:label "Desired Inventory Coverage ";
     skos:altLabel "Desired Inventory Reach";
     dcterms:description "Target Inventory Coverage, considered the optimal level for running a business. It is measured in ‘Weeks of inventory’. ";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:51:27.425Z"^^xsd:dateTime.
 <https://example.com#5b71df05-24da-4be4-bc67-ddc5bfdc8d0a> rdf:type rdfs:Resource;
     dcterms:identifier "5b71df05-24da-4be4-bc67-ddc5bfdc8d0a";
     rdfs:label "Pork Cycle";
     dcterms:description "A persistent wave in certain industries, first observed in pork in the 19th century. Semiconductors are also often referred to as suffering from a Pork Cycle. ";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T12:36:59.642Z"^^xsd:dateTime.
 <https://example.com#c557f155-90db-4dc2-9ba1-f5020625cbba> rdf:type rdfs:Resource;
     dcterms:identifier "c557f155-90db-4dc2-9ba1-f5020625cbba";
     rdfs:label "Underutilization ";
     skos:altLabel "Desired Utilization Rate (DUR)";
     dcterms:description "Use of capacity at a level that is lower than desired. ";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-06T05:27:36.181Z"^^xsd:dateTime.
 <https://example.com#6a7749d4-03cc-4946-9756-5c6ab4159f57> rdf:type rdfs:Resource;
     dcterms:identifier "6a7749d4-03cc-4946-9756-5c6ab4159f57";
     rdfs:label "Smoothing";
     dcterms:description "Averaging recent data; See also SES and DES";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-23T06:29:01.947Z"^^xsd:dateTime.
 <https://example.com#0ba579de-85d8-45f5-b749-95c2a6c54d4c> rdf:type rdfs:Resource;
     dcterms:identifier "0ba579de-85d8-45f5-b749-95c2a6c54d4c";
     rdfs:label "Lagging";
     dcterms:description "Being later in time. E.g. a delivery is always later than the order: the delivery is lagging the order. Is not only caused by lead time but also by averaging or smoothing of data.";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#2d93a0a3-cb4f-4682-bb11-e405538e1bfe> rdf:type rdfs:Resource;
     dcterms:identifier "2d93a0a3-cb4f-4682-bb11-e405538e1bfe";
     rdfs:label "Overshoot";
     dcterms:description "Exceed a target. The opposite is Undershoot. Can e.g. be caused by extrapolation of a changing signal. ";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#a68d9413-ec72-4741-b6c8-6b8c0aa5335f> rdf:type rdfs:Resource;
     dcterms:identifier "a68d9413-ec72-4741-b6c8-6b8c0aa5335f";
     rdfs:label "System Dynamics";
     dcterms:description "System dynamics is an approach to understanding the behaviour of complex systems over time. It deals with internal feedback loops and time delays that affect the behaviour of the entire system. What makes using system dynamics different from other approaches to studying complex systems is the use of feedback loops and stocks and flows. These elements help describe how even seemingly simple systems display baffling nonlinearity";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/sweet/terms?iri=http%3A%2F%2Fsweetontology.net%2FphenSystemComplexity%2FSystemDynamics";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#5b890e93-bfaf-480f-89bd-c9a11b1db3de> rdf:type rdfs:Resource;
     dcterms:identifier "5b890e93-bfaf-480f-89bd-c9a11b1db3de";
     rdfs:label "Demand Upstream";
     dcterms:description "Upstream refers to companies that are located closer to the beginning of the supply chain. So Tier1 is located upstream from the OEM. For Demand see Demand.";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#96e3059c-540c-4b03-b13c-71573c598596> rdf:type rdfs:Resource;
     dcterms:identifier "96e3059c-540c-4b03-b13c-71573c598596";
     rdfs:label "Bullwhip Effect";
     dcterms:description "@Needs discussion ...";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:35:02.801Z"^^xsd:dateTime.
 <https://example.com#9be34bbe-7ef6-4cd6-8fb1-7c55086cc5e0> rdf:type rdfs:Resource;
     dcterms:identifier "9be34bbe-7ef6-4cd6-8fb1-7c55086cc5e0";
     rdfs:label "Desired Inventory";
     dcterms:description "Desired Inventory Coverage multiplied with Demand. Measured in units.";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#d8c79103-75d0-45f9-a26c-cc2edb6bceb6> rdf:type rdfs:Resource;
     dcterms:identifier "d8c79103-75d0-45f9-a26c-cc2edb6bceb6";
     rdfs:label "Demand Endmarket ";
     dcterms:description "End Market Demand (EMD) is the wish of consumers to buy products. It can be considered the end of the Supply Chain. EMD pulls product out of the chain.";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#2af7f230-5f50-4c49-810c-b3f99d447455> rdf:type rdfs:Resource;
     dcterms:identifier "2af7f230-5f50-4c49-810c-b3f99d447455";
     rdfs:label "Demand Short-Term ";
     dcterms:description "@Not defined yet";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:49:31.408Z"^^xsd:dateTime.
 <https://example.com#6ec4584c-da72-4e82-8a8c-dbf4eb8648ad> rdf:type rdfs:Resource;
     dcterms:identifier "6ec4584c-da72-4e82-8a8c-dbf4eb8648ad";
     rdfs:label "Ontology";
     dcterms:description "An ontology encompasses a representation, formal naming and definition of the categories, properties and relations between the concepts, data and entities that substantiate one, many or all domains of discourse.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-AT%23Ontology";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#45614f02-6c70-4fcf-811d-1fee1713658b> rdf:type rdfs:Resource;
     dcterms:identifier "45614f02-6c70-4fcf-811d-1fee1713658b";
     rdfs:label "Semantic Technology";
     dcterms:description "@Proposal: A technology that is somehow based on one or many Semantic Web specifications ";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T11:06:39.487Z"^^xsd:dateTime.
 <https://example.com#45b1a74f-a7f1-42e4-9f4f-fc1cb90df1ba> rdf:type rdfs:Resource;
     dcterms:identifier "45b1a74f-a7f1-42e4-9f4f-fc1cb90df1ba";
     rdfs:label "curation";
     dcterms:description "A planned process in which existing data is collected, organized, and improved in preparation for subsequent use.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/sepio/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FSEPIO_0000131";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:40:52.508Z"^^xsd:dateTime.
 <https://example.com#11ed8074-8172-4007-aaee-73cee59dc5c8> rdf:type rdfs:Resource;
     dcterms:identifier "11ed8074-8172-4007-aaee-73cee59dc5c8";
     rdfs:label "Digital Reference Ontology";
     dcterms:description "Semantic Web (Ontology) for semiconductor supply chains and supply chains containing semiconductors";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#5a73f8fe-df81-4525-8c74-301635a49938> rdf:type rdfs:Resource;
     dcterms:identifier "5a73f8fe-df81-4525-8c74-301635a49938";
     rdfs:label "Knowledge Graph";
     dcterms:description "In knowledge representation and reasoning, a knowledge graph is a knowledge base that uses a graph-structured data model or topology to represent and operate on data. Knowledge graphs are often used to store interlinked descriptions of entities – objects, events, situations or abstract concepts – while also encoding the free-form semantics or relationships underlying these entities";
     rdfs:seeAlso "https://en.wikipedia.org/wiki/Knowledge_graph";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#45bc671c-15a1-4ee0-931e-af2f6dd3f08f> rdf:type rdfs:Resource;
     dcterms:identifier "45bc671c-15a1-4ee0-931e-af2f6dd3f08f";
     rdfs:label "Semantic Web Standards";
     dcterms:description "The development of services is simplified if different data providers use common representations for their data. We therefore need a way for data providers to describe their datasets and a means to reference definitions shared with other data providers. These descriptions may include constraints that can be used to validate the data as a basis for checking for internal consistency. Communities of data providers and consumers have a common interest in defining and using such standards. The kinds of standards will vary considerably. Some are community based, whilst others require international agreements involving a more formal approach for how they are developed and maintained.  W3C aims to support lightweight community based standards that can be incubated within W3C Community Groups, and if appropriate, transferred to Working Groups where a formal standards track process is desired, e.g. for core standards where a greater level of scrutiny is needed.";
     rdfs:seeAlso "https://www.w3.org/2017/12/odi-study/";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T11:08:25.120Z"^^xsd:dateTime.
 <https://example.com#5bc9a44a-91c8-448e-813c-61b012d27ff3> rdf:type rdfs:Resource;
     dcterms:identifier "5bc9a44a-91c8-448e-813c-61b012d27ff3";
     rdfs:label "free-form semantics or relationships";
     dcterms:description "Felix?";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#c7f3da60-5199-4465-8e31-277b45784236> rdf:type rdfs:Resource;
     dcterms:identifier "c7f3da60-5199-4465-8e31-277b45784236";
     rdfs:label "Semantic Web";
     dcterms:description "In addition to the classic “Web of documents” W3C is helping to build a technology stack to support a “Web of data,” the sort of data you find in databases. The ultimate goal of the Web of data is to enable computers to do more useful work and to develop systems that can support trusted interactions over the network. The term “Semantic Web” refers to W3C’s vision of the Web of linked data. Semantic Web technologies enable people to create data stores on the Web, build vocabularies, and write rules for handling data. Linked data are empowered by technologies such as RDF, SPARQL, JSON-LD, OWL, SHACL and SKOS. (Taken from: https://www.w3.org/2001/sw/wiki/Main_Page) Ps: RDF, SPARQL, JSON-LD, OWL, SHACL and SKOS are Semantic Web specifications";
     rdfs:seeAlso "https://www.w3.org/2001/sw/wiki/Main_Page";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T11:07:21.119Z"^^xsd:dateTime.
 <https://example.com#29a4abf9-d093-4598-af4e-93e26d364af5> rdf:type rdfs:Resource;
     dcterms:identifier "29a4abf9-d093-4598-af4e-93e26d364af5";
     rdfs:label "Inventory Coverage";
     skos:altLabel "Inventory Reach", "Days of Inventory";
     dcterms:description "Inventory Coverage is a measure of how long a company‘s current inventory will last under normal sales conditions. It is measured in time (e.g. weeks).";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-06T05:29:21.158Z"^^xsd:dateTime.
 <https://example.com#0812332a-b27d-4ae4-94b6-71076d4e76c7> rdf:type rdfs:Resource;
     dcterms:identifier "0812332a-b27d-4ae4-94b6-71076d4e76c7";
     rdfs:label "Desired Utilization Rate (DUR)";
     dcterms:description "The level of usage of a capacity that is considered optimal from a business point of view. DUR is industry specific. A low DUR gives flexibility, but less turnover so less coverage of fixed cost. ";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#e73367f5-3971-4e94-8f95-6ce4aff94578> rdf:type rdfs:Resource;
     dcterms:identifier "e73367f5-3971-4e94-8f95-6ce4aff94578";
     rdfs:label "Fab";
@@ -197,14 +225,16 @@
     dcterms:description "The name of the fab producing the product. Production Area";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-GDM%23Fab";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:54:18.841Z"^^xsd:dateTime.
 <https://example.com#527c5858-7259-4ede-804a-5c89fc8c6467> rdf:type rdfs:Resource;
     dcterms:identifier "527c5858-7259-4ede-804a-5c89fc8c6467";
     rdfs:label "Dicing";
     dcterms:description "process of cutting semiconductor wafer into individual chips each containing a complete semiconductor device. Large diameter wafer dicing is carried out by partially cutting the wafer along preferred crystallographic planes using high precision saw with ultra-thin diamond blade. ";
     rdfs:seeAlso "https://secure.thresholdsystems.com/KnowledgeCenter/Glossary.aspx#F";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#0c8d7d97-2f0c-489e-9820-ee8647850254> rdf:type rdfs:Resource;
     dcterms:identifier "0c8d7d97-2f0c-489e-9820-ee8647850254";
     rdfs:label "Front End";
@@ -212,7 +242,8 @@
     dcterms:description "In semiconductor manufacturing, the fabrication process in which the integrated circuit is formed in and on the wafer. Compare back end.";
     rdfs:seeAlso "https://secure.thresholdsystems.com/KnowledgeCenter/Glossary.aspx";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:55:57.619Z"^^xsd:dateTime.
 <https://example.com#86a9c39e-c3c0-40db-a9c6-e1b2cdb07a82> rdf:type rdfs:Resource;
     dcterms:identifier "86a9c39e-c3c0-40db-a9c6-e1b2cdb07a82";
     rdfs:label "Back End";
@@ -220,49 +251,56 @@
     dcterms:description "In semiconductor manufacturing, it contains the last stages of production with the package, assembly and test stages. Includes burn-in and environmental test functions. Back End stages implement the production from Front End stages.  Back End and Front End are generally performed in two distinct factories (fab).";
     rdfs:seeAlso "https://secure.thresholdsystems.com/KnowledgeCenter/Glossary.aspx";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:32:18.664Z"^^xsd:dateTime.
 <https://example.com#e718d17a-4f24-4a9c-acb4-7e144ec14fe4> rdf:type rdfs:Resource;
     dcterms:identifier "e718d17a-4f24-4a9c-acb4-7e144ec14fe4";
     rdfs:label "Foundry";
     dcterms:description "A wafer production and processing plant. Usually used to denote a facility that is available on a contract basis to companies that do not have wafer fab capability of their own, or that wish to supplement their own capabilities.";
     rdfs:seeAlso "https://secure.thresholdsystems.com/KnowledgeCenter/Glossary.aspx";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-18T14:01:23.862Z"^^xsd:dateTime.
 <https://example.com#b6f6559b-9d69-4128-8d20-2528a986d7cb> rdf:type rdfs:Resource;
     dcterms:identifier "b6f6559b-9d69-4128-8d20-2528a986d7cb";
     rdfs:label "NAND Type Flash Memory";
     dcterms:description "A type of non-volatile memory medium invented in 1987 by Fujio Masuoka (then a Toshiba employee). Compared to the NOR type flash memory, NAND flash is smaller in circuit scale, less costly, and offers larger capacities as well as faster read/write speeds. NAND flash is widely used for USB drives, memory cards for digital cameras, and storage devices for mobile phones and digital music players. As conventional chip scaling technology is reaching its limits, 3D structures have been introduced in flash memory devices in recent years.";
     rdfs:seeAlso "https://secure.thresholdsystems.com/KnowledgeCenter/Glossary.aspx";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#378edb24-3b87-4f54-b8e2-dcc748f1a7cd> rdf:type rdfs:Resource;
     dcterms:identifier "378edb24-3b87-4f54-b8e2-dcc748f1a7cd";
     rdfs:label "Flash Memory";
     dcterms:description "An advanced form of electrically erasable programmable read-only memory (EEPROM). Flash memory is non-volatile and the data on the device can be freely rewritten. Flash memory devices are more convenient to use than UVEPROMs that require ultraviolet light to erase data.";
     rdfs:seeAlso "https://secure.thresholdsystems.com/KnowledgeCenter/Glossary.aspx";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#fe66ac5e-fd80-4a2a-b209-5c7698a31f85> rdf:type rdfs:Resource;
     dcterms:identifier "fe66ac5e-fd80-4a2a-b209-5c7698a31f85";
     rdfs:label "Node";
     dcterms:description "@Need description";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-06T08:02:42.036Z"^^xsd:dateTime.
 <https://example.com#c67e3931-e4df-41c8-acf1-ef581772784c> rdf:type rdfs:Resource;
     dcterms:identifier "c67e3931-e4df-41c8-acf1-ef581772784c";
     rdfs:label "Node Technology Group";
     dcterms:description "@No description available yet";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-06T08:00:54.635Z"^^xsd:dateTime.
 <https://example.com#4c628f7c-9cb3-419d-92d2-46be565301d1> rdf:type rdfs:Resource;
     dcterms:identifier "4c628f7c-9cb3-419d-92d2-46be565301d1";
     rdfs:label "Binning";
     dcterms:description "BINNING refers to the process of testing and categorizing parts against defined measures and sort them into different bins (Degbotse 2013). Each bin belongs to certain levels of defined measures (e.g. chip speed, current, voltage, energy consumption). Binning is often combined with SUBSTITUTION.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Binning";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#dd1eb576-d83b-4d0d-ac05-d8d09d0e1264> rdf:type rdfs:Resource;
     dcterms:identifier "dd1eb576-d83b-4d0d-ac05-d8d09d0e1264";
     rdfs:label "Bill Of Material";
@@ -270,42 +308,48 @@
     dcterms:description "A BILL OF MATERIALS (BOM) describes the component products used to make another product. Substitution, often associated with binning, is based on the possibility that alternative items might be used to finish a process step.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Bill_Of_Material";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-07-04T08:33:09.428Z"^^xsd:dateTime.
 <https://example.com#268e91b4-77f7-4a77-a41d-5ce3bb322524> rdf:type rdfs:Resource;
     dcterms:identifier "268e91b4-77f7-4a77-a41d-5ce3bb322524";
     rdfs:label "Random coproduction ";
     dcterms:description "@Not defined yet";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-06T08:09:23.434Z"^^xsd:dateTime.
 <https://example.com#d0600216-6f78-4976-a660-a3066baae7da> rdf:type rdfs:Resource;
     dcterms:identifier "d0600216-6f78-4976-a660-a3066baae7da";
     rdfs:label "Borderless Fab Setting";
     dcterms:description "@Not defined yet";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:34:47.074Z"^^xsd:dateTime.
 <https://example.com#8be0ebc9-cbee-4ebd-9a54-feb7366b65dc> rdf:type rdfs:Resource;
     dcterms:identifier "8be0ebc9-cbee-4ebd-9a54-feb7366b65dc";
     rdfs:label "Base Wafers";
     dcterms:description "Not defined yet";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-06T08:09:23.434Z"^^xsd:dateTime.
 <https://example.com#6adb2b83-e698-405f-9eb0-38dde30d7922> rdf:type rdfs:Resource;
     dcterms:identifier "6adb2b83-e698-405f-9eb0-38dde30d7922";
     rdfs:label "MAPE";
     dcterms:description "Mean Absolute Percentage Error";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-06T08:13:13.110Z"^^xsd:dateTime.
 <https://example.com#010831c3-ef72-4194-98cf-950e039f178e> rdf:type rdfs:Resource;
     dcterms:identifier "010831c3-ef72-4194-98cf-950e039f178e";
     rdfs:label "NCNR orders";
     dcterms:description "non-cancellable non-refundable orders";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#abeb6a5c-cc98-4921-a42e-f90b6d6f9533> rdf:type rdfs:Resource;
     dcterms:identifier "abeb6a5c-cc98-4921-a42e-f90b6d6f9533";
     rdfs:label "Chip";
@@ -313,7 +357,8 @@
     dcterms:description "A single square or rectangular piece of semiconductor material into which a specific electrical circuit has been fabricated. Plural: dice. Also called a chip.";
     rdfs:seeAlso "https://secure.thresholdsystems.com/KnowledgeCenter/Glossary.aspx";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:36:42.210Z"^^xsd:dateTime.
 <https://example.com#376d968c-83f7-44fa-9470-e4c0bc0cc5ee> rdf:type rdfs:Resource;
     dcterms:identifier "376d968c-83f7-44fa-9470-e4c0bc0cc5ee";
     rdfs:label "Die";
@@ -321,14 +366,16 @@
     dcterms:description "a single piece of semiconductor containing entire integrated circuit which has not yet been packaged; A chip.";
     rdfs:seeAlso "https://secure.thresholdsystems.com/KnowledgeCenter/Glossary.aspx";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#e655023c-d74f-410a-92f8-8d600cd72d96> rdf:type rdfs:Resource;
     dcterms:identifier "e655023c-d74f-410a-92f8-8d600cd72d96";
     rdfs:label "Die Bank";
     dcterms:description "A die bank is an area in production where (usually) tested wafers are stored waiting for disposition and further production.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Die_Bank";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:53:17.635Z"^^xsd:dateTime.
 <https://example.com#68392d7e-0253-4edc-96ef-d6f9c8306649> rdf:type rdfs:Resource;
     dcterms:identifier "68392d7e-0253-4edc-96ef-d6f9c8306649";
     rdfs:label "Capacity Bottleneck";
@@ -336,21 +383,24 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Capacity_Bottleneck";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-04-23T09:36:18.089Z"^^xsd:dateTime.
 <https://example.com#5990ff8a-be1c-4485-a18d-1eb64db342e3> rdf:type rdfs:Resource;
     dcterms:identifier "5990ff8a-be1c-4485-a18d-1eb64db342e3";
     rdfs:label "Business Cycle";
     dcterms:description "Periods of prosperity generally followed by periods of depression make up what is called the business cycle. Such cycles tend to vary in length and magnitude and are often dealt with as a separate subcomponent of the basic pattern contained in a time series.";
     rdfs:seeAlso "https://robjhyndman.com/mwh3/FG4.pdf";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:35:32.725Z"^^xsd:dateTime.
 <https://example.com#8c989a43-5f21-4109-8ceb-2122a7e7bb6e> rdf:type rdfs:Resource;
     dcterms:identifier "8c989a43-5f21-4109-8ceb-2122a7e7bb6e";
     rdfs:label "Exponential Smoothing";
     dcterms:description "Exponential smoothing methods provide forecasts using weighted averages of past values of the data and forecast errors. They are commonly used in inventory control systems where many items are to be forecast and low cost is a primary concern. The simplest exponential smoothing method is single exponential smoothing (SES), suitable for data with no trend or seasonal patterns. For trended data, Holt’s method is suitable and for seasonal data, Holt-Winters’ method may be used. Pegels’ classification provides a convenient structure in which to study and apply exponential smoothing methods";
     rdfs:seeAlso "https://robjhyndman.com/mwh3/FG4.pdf";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-09T12:14:40.511Z"^^xsd:dateTime.
 <https://example.com#f452a6e2-b533-4a5a-8b36-60d2115d63e3> rdf:type rdfs:Resource;
     dcterms:identifier "f452a6e2-b533-4a5a-8b36-60d2115d63e3";
     rdfs:label "Aggregated Capacity";
@@ -358,7 +408,8 @@
     dcterms:description "(restricted) The Aggregated Capacity Group combines products that are interchangeable in production resources (e.g. can be produced on the same equipment) and having the same capacity consumption. Using an ACG provides flexibility in a way of switching demands of this products within this ACG.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Aggregated_Capacity";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#c66b03e7-249c-4bf8-962d-8a37200f2ae3> rdf:type rdfs:Resource;
     dcterms:identifier "c66b03e7-249c-4bf8-962d-8a37200f2ae3";
     rdfs:label "Confirmation";
@@ -366,7 +417,8 @@
     dcterms:description "Order acknowledgement";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Confirmation";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#3be8feac-f780-4f0b-80a3-dc4198d48884> rdf:type rdfs:Resource;
     dcterms:identifier "3be8feac-f780-4f0b-80a3-dc4198d48884";
     rdfs:label "Criteria";
@@ -374,7 +426,8 @@
     dcterms:description "Typical criteria are maximization, minimization, i.e. if an optimization problem is considered, or larger or smaller than a prescribed value of the certain performance measure, a so-called target, i.e. if a satisfaction problem is solved. In a multi-criteria setting, the dominance concept for plans is of interest.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Criteria";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-11-20T10:14:36.291Z"^^xsd:dateTime.
 <https://example.com#73d4e9a6-26b1-46be-ba9d-76886361c851> rdf:type rdfs:Resource;
     dcterms:identifier "73d4e9a6-26b1-46be-ba9d-76886361c851";
     rdfs:label "Customer Logistics Management Representative";
@@ -382,7 +435,8 @@
     dcterms:description "Being the main interface between Customer, Sales and the Supply Chain Planner he is responsible for the demand fulfilment process. It is his task to ensure in-time delivery to customers based on orders and forecasts and to achieve high customer satisfaction.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Customer_Logistics_Management_Representative";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:43:02.604Z"^^xsd:dateTime.
 <https://example.com#71fabe0a-bb3f-4e93-83df-daa77c1eb6be> rdf:type rdfs:Resource;
     dcterms:identifier "71fabe0a-bb3f-4e93-83df-daa77c1eb6be";
     rdfs:label "Edge";
@@ -390,7 +444,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Edge";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#74bdfced-5c3d-4263-8f34-5984a527affb> rdf:type rdfs:Resource;
     dcterms:identifier "74bdfced-5c3d-4263-8f34-5984a527affb";
     rdfs:label "General Customers";
@@ -398,7 +453,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23General_Customer";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#517f5c4a-195e-4d71-9748-b81848e9a445> rdf:type rdfs:Resource;
     dcterms:identifier "517f5c4a-195e-4d71-9748-b81848e9a445";
     rdfs:label "Marketing Demand";
@@ -406,7 +462,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Marketing_Demand";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#c44016c0-d377-4a93-9f22-57bbda510700> rdf:type rdfs:Resource;
     dcterms:identifier "c44016c0-d377-4a93-9f22-57bbda510700";
     rdfs:label "nEWs";
@@ -414,7 +471,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23NEWs";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-11-20T10:03:25.599Z"^^xsd:dateTime.
 <https://example.com#9990fa2f-c4c8-45e4-9201-26ee4ccc90e6> rdf:type rdfs:Resource;
     dcterms:identifier "9990fa2f-c4c8-45e4-9201-26ee4ccc90e6";
     rdfs:label "Operational Demand";
@@ -422,7 +480,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Operational_Demand";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#273e9482-c646-4a28-a0a0-8bbdffb94951> rdf:type rdfs:Resource;
     dcterms:identifier "273e9482-c646-4a28-a0a0-8bbdffb94951";
     rdfs:label "Order Reschedule";
@@ -430,7 +489,8 @@
     dcterms:description "Any change in the requested order delivery date in an order line is referred to as an order rescheduling.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Order_Reschedule";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#f1595613-c2b3-47b6-b0e8-9c4ecdf222eb> rdf:type rdfs:Resource;
     dcterms:identifier "f1595613-c2b3-47b6-b0e8-9c4ecdf222eb";
     rdfs:label "Order Schedule Line";
@@ -438,7 +498,8 @@
     dcterms:description "Schedule lines contain all the delivery related information";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Order_Schedule_Line";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#4d99b9e6-b577-4cbc-bbfc-e900ae27979a> rdf:type rdfs:Resource;
     dcterms:identifier "4d99b9e6-b577-4cbc-bbfc-e900ae27979a";
     rdfs:label "Plan Execution";
@@ -446,7 +507,8 @@
     dcterms:description "A PLAN EXECUTION is related to performing the activities according to a PLAN either directly in the base system, for instance, releasing lots into a wafer fab, or as instructions for another DECISION-MAKING UNIT.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Plan_Execution";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#059720b0-2438-47d0-a07d-14350ba1580c> rdf:type rdfs:Resource;
     dcterms:identifier "059720b0-2438-47d0-a07d-14350ba1580c";
     rdfs:label "Planning";
@@ -454,7 +516,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Planning";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T12:38:15.247Z"^^xsd:dateTime.
 <https://example.com#890da0b3-74ae-451c-9de6-59557917c973> rdf:type rdfs:Resource;
     dcterms:identifier "890da0b3-74ae-451c-9de6-59557917c973";
     rdfs:label "Planning Approach";
@@ -462,7 +525,8 @@
     dcterms:description "Specific planning algorithm which is used in a deticated planning process";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Planning_Approach";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#5964a671-3e1f-4718-9a7f-17c01614d745> rdf:type rdfs:Resource;
     dcterms:identifier "5964a671-3e1f-4718-9a7f-17c01614d745";
     rdfs:label "Planning Constraint";
@@ -470,7 +534,8 @@
     dcterms:description "A PLANNING CONSTRAINT restricts the action space. This space is formed by alternative actions that are a result of the planning decisions (Schneeweis 2003). In the planning domain, PLANNING CONSTRAINTS, often the capacity offered by resources, limit the quantities that are assigned to the PLANNING OBJECTS or impact the temporal properties of PLANNING OBJECTS.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Planning_Constraint";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#33a63ab3-941d-4406-ae50-61b19ed8d6c5> rdf:type rdfs:Resource;
     dcterms:identifier "33a63ab3-941d-4406-ae50-61b19ed8d6c5";
     rdfs:label "Planning Decision";
@@ -478,7 +543,8 @@
     dcterms:description "Decisions determined by a Decision Making Unit";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Planning_Decision";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#48b9fc4b-cdbc-465a-b3a3-e82fbdb2e7cd> rdf:type rdfs:Resource;
     dcterms:identifier "48b9fc4b-cdbc-465a-b3a3-e82fbdb2e7cd";
     rdfs:label "Planning Function";
@@ -486,7 +552,8 @@
     dcterms:description "Describes the different functions and its properies follwing the supply chain planning matrix.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Planning_Function";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#abbe6e87-adf3-4d13-8760-df24199be1d1> rdf:type rdfs:Resource;
     dcterms:identifier "abbe6e87-adf3-4d13-8760-df24199be1d1";
     rdfs:label "Planning Instance";
@@ -494,7 +561,8 @@
     dcterms:description "A PLANNING INSTANCE specifies the PLANNING OBJECTS and the values of related PLANNING CONSTRAINTS that form the basis for a planning decision.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Planning_Instance";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#46f11fca-a0a9-4581-9f7a-b03a576c422e> rdf:type rdfs:Resource;
     dcterms:identifier "46f11fca-a0a9-4581-9f7a-b03a576c422e";
     rdfs:label "Planning Object";
@@ -502,7 +570,8 @@
     dcterms:description "A PLANNING OBJECT specifies what has to be planned as an atomic unit. A single PLANNING OBJECT typically represents a quantity of a certain product or product aggregate to be released or completed within a certain period in a certain node of the semiconductor supply chain. Other PLANNING OBJECTS can be orders or lots. Values are assigned to the attributes of a PLANNING OBJECT as a result of a planning decision.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Planning_Object";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#ecb78b67-66ae-4cca-b67b-d59df3e1dd85> rdf:type rdfs:Resource;
     dcterms:identifier "ecb78b67-66ae-4cca-b67b-d59df3e1dd85";
     rdfs:label "Planning Process";
@@ -510,7 +579,8 @@
     dcterms:description "The PLANNING PROCESS specifies under which circumstances which (re)planning activities are performed by a DECISION-MAKING UNIT.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Planning_Process";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#befe64f1-f538-4092-929f-a26e1ad221f2> rdf:type rdfs:Resource;
     dcterms:identifier "befe64f1-f538-4092-929f-a26e1ad221f2";
     rdfs:label "Planning Situation";
@@ -518,7 +588,8 @@
     dcterms:description "The PLANNING SITUATION describes the organization of several DECISION-MAKING UNITS and also its environment.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Planning_Situation";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#e5affe98-acd0-4072-b8ca-6585615fa17e> rdf:type rdfs:Resource;
     dcterms:identifier "e5affe98-acd0-4072-b8ca-6585615fa17e";
     rdfs:label "Hierarchical Situation";
@@ -526,7 +597,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Hierarchical_Situation";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#982a684c-ce5d-428a-ac96-abc0cbdacabf> rdf:type rdfs:Resource;
     dcterms:identifier "982a684c-ce5d-428a-ac96-abc0cbdacabf";
     rdfs:label "Frozen Fence";
@@ -534,7 +606,8 @@
     dcterms:description "FROZEN FENCE is used to set a frozen interval  in which decision making is not allowed to change the previously determined values.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Frozen_Fence";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#3ac22854-9d82-4a5d-a593-a6042a3c35e9> rdf:type rdfs:Resource;
     dcterms:identifier "3ac22854-9d82-4a5d-a593-a6042a3c35e9";
     rdfs:label "Decison Making Unit Character";
@@ -542,7 +615,8 @@
     dcterms:description "In an ANTAGO¬NISTIC SETTING, the different DECISION-MAKING UNITS try to meet their own objectives which are in conflict. In a non-antagonistic setting, the DECISION-MAKING UNITS do not exploit their private knowledge in an opportunistic way.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Decison_Making_Unit_Character";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#9d5f5d9f-e68b-4a72-92c9-2bcc092995d3> rdf:type rdfs:Resource;
     dcterms:identifier "9d5f5d9f-e68b-4a72-92c9-2bcc092995d3";
     rdfs:label "Decision Making Unit";
@@ -550,7 +624,8 @@
     dcterms:description "The DECISION-MAKING UNIT specifies an instance that makes decisions.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Decision_Making_Unit";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#f66d0722-82ba-4d95-9c0e-b41f201e1a9c> rdf:type rdfs:Resource;
     dcterms:identifier "f66d0722-82ba-4d95-9c0e-b41f201e1a9c";
     rdfs:label "Decision Making Initiative";
@@ -558,7 +633,8 @@
     dcterms:description "We distinguish fully autonomous DECISION-MAKING UNITS from DECISION-MAKING UNITS where the decision-making activities are triggered by other DECISION-MAKING UNITS. Note that the decision-making initiative can change over time in a situation-dependent manner.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Decision_Making_Initiative";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#8abf76e2-86fd-4d23-93a7-261722b03967> rdf:type rdfs:Resource;
     dcterms:identifier "8abf76e2-86fd-4d23-93a7-261722b03967";
     rdfs:label "Decision Maker Type";
@@ -566,7 +642,8 @@
     dcterms:description "We distinguish human decision-makers (human DECISION-MAKING UNITS) from fully automated DECISION-MAKING UNITS where computers make fully automated decisions. Between these two extremes there are semi-automated decisions, where a computer provides several decision alternatives and a human decision-maker chooses among them. Note that the decision-maker type can change over time.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Decision_Maker_Type";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#db95fcf6-d753-4a4a-8472-38d3a55e7eb8> rdf:type rdfs:Resource;
     dcterms:identifier "db95fcf6-d753-4a4a-8472-38d3a55e7eb8";
     rdfs:label "Prioritized Demand";
@@ -574,7 +651,8 @@
     dcterms:description "The demand that should be covered first.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Prioritized_Demand";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#93b67611-5243-4e71-a561-d68ee396d859> rdf:type rdfs:Resource;
     dcterms:identifier "93b67611-5243-4e71-a561-d68ee396d859";
     rdfs:label "Prioritized Orders";
@@ -582,7 +660,8 @@
     dcterms:description "Orders that should be completed first.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Prioritized_Orders";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#b833fb54-a3dd-4843-8deb-541138ef5eec> rdf:type rdfs:Resource;
     dcterms:identifier "b833fb54-a3dd-4843-8deb-541138ef5eec";
     rdfs:label "Process";
@@ -590,7 +669,8 @@
     dcterms:description "A collection of subprocesses that meet a specific business objective. E.g. Perform Sourcing or Purchase Materials and Services";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-PMV%23Process";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#8445acc4-4300-4c9b-a9af-20994259b18f> rdf:type rdfs:Resource;
     dcterms:identifier "8445acc4-4300-4c9b-a9af-20994259b18f";
     rdfs:label "Promise";
@@ -598,7 +678,8 @@
     dcterms:description "Is the uncommitted portion of supply by the master production schedule and material plan";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Promise";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-18T14:16:45.304Z"^^xsd:dateTime.
 <https://example.com#1ccbb124-456d-4c64-9d8e-748d7f2ee139> rdf:type rdfs:Resource;
     dcterms:identifier "1ccbb124-456d-4c64-9d8e-748d7f2ee139";
     rdfs:label "Replanning Degree";
@@ -606,7 +687,8 @@
     dcterms:description "The degree distinguishes replanning from scratch and repair of existing plans (Vieria et al. 2003).";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Replanning_Degree";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#5e8e7a2c-5de6-4a74-a250-cc7195bbbe50> rdf:type rdfs:Resource;
     dcterms:identifier "5e8e7a2c-5de6-4a74-a250-cc7195bbbe50";
     rdfs:label "Sales Demand";
@@ -614,7 +696,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Sales_Demand";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T11:04:23.449Z"^^xsd:dateTime.
 <https://example.com#b7277f2f-cef0-4188-81b8-be78f4869e56> rdf:type rdfs:Resource;
     dcterms:identifier "b7277f2f-cef0-4188-81b8-be78f4869e56";
     rdfs:label "Supply Demand Match";
@@ -622,7 +705,8 @@
     dcterms:description "Supply and demand match when sufficient materials exist to cover material demand while taking available capacity into account.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Supply_Demand_Match";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T11:01:08.338Z"^^xsd:dateTime.
 <https://example.com#20aa6325-719a-4666-81f6-6d055ee97527> rdf:type rdfs:Resource;
     dcterms:identifier "20aa6325-719a-4666-81f6-6d055ee97527";
     rdfs:label "Supply Picture";
@@ -630,7 +714,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Supply_Picture";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#aa266f71-b4da-4673-8fa6-117fb0aa52f7> rdf:type rdfs:Resource;
     dcterms:identifier "aa266f71-b4da-4673-8fa6-117fb0aa52f7";
     rdfs:label "Target";
@@ -638,7 +723,8 @@
     dcterms:description "Targets are prescribed values for the different performance measures.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Target";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T11:01:36.189Z"^^xsd:dateTime.
 <https://example.com#ebb5cfcb-9199-45ef-b0ff-87916086a19a> rdf:type rdfs:Resource;
     dcterms:identifier "ebb5cfcb-9199-45ef-b0ff-87916086a19a";
     rdfs:label "Target Allocation";
@@ -646,7 +732,8 @@
     dcterms:description "The target allocation is the level of allocation planned by the company.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Target_Allocation";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#214144da-cbaa-4950-ac65-70c46ded293f> rdf:type rdfs:Resource;
     dcterms:identifier "214144da-cbaa-4950-ac65-70c46ded293f";
     rdfs:label "Vertex";
@@ -654,55 +741,63 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Vertex";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-11-20T10:05:04.910Z"^^xsd:dateTime.
 <https://example.com#f7637daf-b71b-4ced-8b54-888c21a4ed22> rdf:type rdfs:Resource;
     dcterms:identifier "f7637daf-b71b-4ced-8b54-888c21a4ed22";
     rdfs:label "Technology node";
     dcterms:description "to be defined";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#5ec8e410-2180-4a1a-87c2-30e68a684555> rdf:type rdfs:Resource;
     dcterms:identifier "5ec8e410-2180-4a1a-87c2-30e68a684555";
     rdfs:label "Capacity Utilization";
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/scor/terms?iri=http%3A%2F%2Fpurl.org%2Feis%2Fvocab%2Fscor%23hasMetricAM_9";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-04-23T09:37:26.512Z"^^xsd:dateTime.
 <https://example.com#763f9faa-f1e1-4265-ae07-b65eafc9b570> rdf:type rdfs:Resource;
     dcterms:identifier "763f9faa-f1e1-4265-ae07-b65eafc9b570";
     rdfs:label "inventory target";
     dcterms:description "target set by a company for their inventory level";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#1a5b2876-b03f-4237-aa07-12f33befade3> rdf:type rdfs:Resource;
     dcterms:identifier "1a5b2876-b03f-4237-aa07-12f33befade3";
     rdfs:label "finished goods";
     dcterms:description "finished product ";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#2aff4e35-8f80-4b3d-95f7-9b27b39cbef5> rdf:type rdfs:Resource;
     dcterms:identifier "2aff4e35-8f80-4b3d-95f7-9b27b39cbef5";
     rdfs:label "absolute number";
     dcterms:description "quantity";
     rdfs:seeAlso "N/A";
     ex:status "reject";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-30T09:52:30.476Z"^^xsd:dateTime.
 <https://example.com#de4cfbaf-964f-4eb0-a155-c9f66340d260> rdf:type rdfs:Resource;
     dcterms:identifier "de4cfbaf-964f-4eb0-a155-c9f66340d260";
     rdfs:label "relative number";
     dcterms:description "percentage";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#b5a1f564-89dd-4896-b162-1a859d4aadf1> rdf:type rdfs:Resource;
     dcterms:identifier "b5a1f564-89dd-4896-b162-1a859d4aadf1";
     rdfs:label "forecast";
     dcterms:description "A forecast is an information content entity that contains statements about the most probable future development predicted with the help of past and present data.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/oeo/terms?iri=http%3A%2F%2Fopenenergy-platform.org%2Fontology%2Foeo%2FOEO_00010411";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#a1eb4e31-3527-41b0-8424-9b38c53f930c> rdf:type rdfs:Resource;
     dcterms:identifier "a1eb4e31-3527-41b0-8424-9b38c53f930c";
     rdfs:label "days of inventory";
@@ -710,63 +805,72 @@
     dcterms:description "how long a companies inventory will last if production was stopped today in days";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#10d17e72-df2e-400f-811e-16c018121d33> rdf:type rdfs:Resource;
     dcterms:identifier "10d17e72-df2e-400f-811e-16c018121d33";
     rdfs:label "Shipment";
     dcterms:description "incoming or outgoing good ";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#4784710d-e693-4469-8bb8-be49a65d8380> rdf:type rdfs:Resource;
     dcterms:identifier "4784710d-e693-4469-8bb8-be49a65d8380";
     rdfs:label "Confirmed Order";
     dcterms:description "Order which has been confirmed for fulfillment by the selling company ";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#e7b78a49-567f-47ef-a14f-257e6098360a> rdf:type rdfs:Resource;
     dcterms:identifier "e7b78a49-567f-47ef-a14f-257e6098360a";
     rdfs:label "Unconfirmed Order";
     dcterms:description "Order which has not been confirmed for fulfilment by the selling company";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#4f889db8-3815-4672-8d55-f44cb7e45dc1> rdf:type rdfs:Resource;
     dcterms:identifier "4f889db8-3815-4672-8d55-f44cb7e45dc1";
     rdfs:label "Baseline";
     dcterms:description "A starting point to which things may be compared.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/ncit/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNCIT_C25213";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#8a73b95b-2800-45b6-a7df-94d888fa3e02> rdf:type rdfs:Resource;
     dcterms:identifier "8a73b95b-2800-45b6-a7df-94d888fa3e02";
     rdfs:label "Billing";
     dcterms:description "The process of requesting payment of a debt for goods or services.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/ncit/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNCIT_C88189";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#38d050a5-eebf-4216-a4c8-f462dd7e42d3> rdf:type rdfs:Resource;
     dcterms:identifier "38d050a5-eebf-4216-a4c8-f462dd7e42d3";
     rdfs:label "product category";
     dcterms:description "group of products which sell in the same market ";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#13cb7768-171b-46e6-a2a1-a7df3b47494e> rdf:type rdfs:Resource;
     dcterms:identifier "13cb7768-171b-46e6-a2a1-a7df3b47494e";
     rdfs:label "Survey";
     dcterms:description "method of gather data and information from a group of participants";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#1eb30b69-41c8-47d0-8d45-e199bbaf52d8> rdf:type rdfs:Resource;
     dcterms:identifier "1eb30b69-41c8-47d0-8d45-e199bbaf52d8";
     rdfs:label "Market Demand";
     dcterms:description "Demand of the whole market";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#3ac5a6b8-0cb9-419e-a5aa-736fc3638080> rdf:type rdfs:Resource;
     dcterms:identifier "3ac5a6b8-0cb9-419e-a5aa-736fc3638080";
     rdfs:label "Unique Selling Point ";
@@ -774,28 +878,32 @@
     dcterms:description "is a distinct feature or characteristic that sets a product, service, or brand apart from its competitors";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#5c26698d-2566-411c-8e03-6fd1bc37350d> rdf:type rdfs:Resource;
     dcterms:identifier "5c26698d-2566-411c-8e03-6fd1bc37350d";
     rdfs:label "Lead Time";
     dcterms:description "This term refers to the time interval between two events, when one must precede the other. In many inventory and order entry systems, the lead time is the interval between the time when an order is placed and the time when it is actually delivered.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23lead_time";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-23T06:24:59.422Z"^^xsd:dateTime.
 <https://example.com#52362a0d-517b-4d41-969c-dd4c47a657e4> rdf:type rdfs:Resource;
     dcterms:identifier "52362a0d-517b-4d41-969c-dd4c47a657e4";
     rdfs:label "time";
     dcterms:description "This property is required to manage timing aspects of a PLANNING OBJECT. It can be a release time, a finishing time, a single start time, or a set of start time for certain ACTIVITIES to be fulfilled.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23time";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T11:02:58.974Z"^^xsd:dateTime.
 <https://example.com#a3a6033c-6eb2-459d-b60d-7898b1fde5d6> rdf:type rdfs:Resource;
     dcterms:identifier "a3a6033c-6eb2-459d-b60d-7898b1fde5d6";
     rdfs:label "Granularity";
     dcterms:description "A data unit, as part of the whole collection of data, that has a high level of detail in distinct parts.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/ncit/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FNCIT_C142567";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-09-18T14:05:58.638Z"^^xsd:dateTime.
 <https://example.com#1ccc7b36-6107-4ec4-8b83-4d9965ad12ab> rdf:type rdfs:Resource;
     dcterms:identifier "1ccc7b36-6107-4ec4-8b83-4d9965ad12ab";
     rdfs:label "Transparency Graph";
@@ -803,49 +911,56 @@
     dcterms:description "graph that can translate market segment information to technology nodes";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-11-20T10:08:24.551Z"^^xsd:dateTime.
 <https://example.com#0bcc10a1-cf8b-471d-829c-ad6c2c9e9953> rdf:type rdfs:Resource;
     dcterms:identifier "0bcc10a1-cf8b-471d-829c-ad6c2c9e9953";
     rdfs:label "Substrate";
     dcterms:description "a substrate is the foundational material upon which semiconductor devices are built";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#e7e18bb5-a4f8-4c58-b82a-e376518cf1e9> rdf:type rdfs:Resource;
     dcterms:identifier "e7e18bb5-a4f8-4c58-b82a-e376518cf1e9";
     rdfs:label "Semiconductor Product Category";
     dcterms:description "Classification of semiconductor products based on their functionality, application and technical characteristics";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#d72bc058-65ba-4312-a78e-ca69a3dce947> rdf:type rdfs:Resource;
     dcterms:identifier "d72bc058-65ba-4312-a78e-ca69a3dce947";
     rdfs:label "Analog Integrated Circuit";
     dcterms:description " type of semiconductor device that processes continuous signals to perform functions such as amplification, filtering, and modulation";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:31:55.937Z"^^xsd:dateTime.
 <https://example.com#a000906b-76cd-4062-a61d-37a701dd1e99> rdf:type rdfs:Resource;
     dcterms:identifier "a000906b-76cd-4062-a61d-37a701dd1e99";
     rdfs:label "Microcontroller";
     dcterms:description "is a compact integrated circuit designed to perform specific control functions within embedded systems";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#bbc74c26-805f-4f43-b0db-c2d26d00feca> rdf:type rdfs:Resource;
     dcterms:identifier "bbc74c26-805f-4f43-b0db-c2d26d00feca";
     rdfs:label "Microprocessor";
     dcterms:description "is a central processing unit (CPU) on a single integrated circuit that executes instructions to perform general-purpose computing tasks.";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#63ba7ec6-b318-4745-8285-b48d7e23bdca> rdf:type rdfs:Resource;
     dcterms:identifier "63ba7ec6-b318-4745-8285-b48d7e23bdca";
     rdfs:label "Logic Integrated Circuits";
     dcterms:description "is a semiconductor device that performs logical operations on digital signals";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#e41e8cf4-eb87-4509-9014-42da7a5e7d07> rdf:type rdfs:Resource;
     dcterms:identifier "e41e8cf4-eb87-4509-9014-42da7a5e7d07";
     rdfs:label "Action";
@@ -853,7 +968,8 @@
     dcterms:description "The process of doing something";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Action";
     ex:status "reject";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-17T15:56:02.697Z"^^xsd:dateTime.
 <https://example.com#7f3329e8-301e-43f1-b5ba-43c4aee22ddd> rdf:type rdfs:Resource;
     dcterms:identifier "7f3329e8-301e-43f1-b5ba-43c4aee22ddd";
     rdfs:label "Allocation";
@@ -861,7 +977,8 @@
     dcterms:description "Allocation is a process used in order management in times when demand exceeds available supply.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Allocation";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:30:00.405Z"^^xsd:dateTime.
 <https://example.com#169f110a-5452-4540-a221-aa31ac5c4f93> rdf:type rdfs:Resource;
     dcterms:identifier "169f110a-5452-4540-a221-aa31ac5c4f93";
     rdfs:label "Contact Person Data";
@@ -869,7 +986,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Contact_Person_Data";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:37:49.779Z"^^xsd:dateTime.
 <https://example.com#9bc8b2c2-0308-4c68-9458-ea2c99869c13> rdf:type rdfs:Resource;
     dcterms:identifier "9bc8b2c2-0308-4c68-9458-ea2c99869c13";
     rdfs:label "Customer Class";
@@ -877,7 +995,8 @@
     dcterms:description "The set of all customers is divided into different priority classes or segments based on certain criteria like profitability or importance of customer.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Customer_Class";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#b06c0614-d923-44c2-8130-fbafe16e6871> rdf:type rdfs:Resource;
     dcterms:identifier "b06c0614-d923-44c2-8130-fbafe16e6871";
     rdfs:label "Customer Data";
@@ -885,7 +1004,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Customer_Data";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:42:36.525Z"^^xsd:dateTime.
 <https://example.com#641e8ab9-516d-4a29-b6f5-efd07781d59a> rdf:type rdfs:Resource;
     dcterms:identifier "641e8ab9-516d-4a29-b6f5-efd07781d59a";
     rdfs:label "Customer Plant";
@@ -893,7 +1013,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Customer_Plant";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#17aee842-7e96-456e-912e-8488117dc755> rdf:type rdfs:Resource;
     dcterms:identifier "17aee842-7e96-456e-912e-8488117dc755";
     rdfs:label "Customer Plant Data";
@@ -901,7 +1022,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Customer_Plant_Data";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#6ab3f1c8-870d-43a8-89c0-6261465c647d> rdf:type rdfs:Resource;
     dcterms:identifier "6ab3f1c8-870d-43a8-89c0-6261465c647d";
     rdfs:label "Delivery Committment";
@@ -909,7 +1031,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-GDM%23Delivery_Committment";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#151064fa-aab0-4edf-bee4-eaf4dd832100> rdf:type rdfs:Resource;
     dcterms:identifier "151064fa-aab0-4edf-bee4-eaf4dd832100";
     rdfs:label "Delivery Concept";
@@ -917,7 +1040,8 @@
     dcterms:description "The deliver concept defines the terms and conditions for delivering an order to the customer. Especially partial and split delivery has to be taken into account.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Delivery_Concept";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#126cdd01-1c9b-45b1-948b-3536474e2766> rdf:type rdfs:Resource;
     dcterms:identifier "126cdd01-1c9b-45b1-948b-3536474e2766";
     rdfs:label "Demand Trace";
@@ -925,7 +1049,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-GDM%23Demand_Trace";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T10:50:07.618Z"^^xsd:dateTime.
 <https://example.com#5c6d4b2d-5c7c-4890-b9d2-9085fa83dfcb> rdf:type rdfs:Resource;
     dcterms:identifier "5c6d4b2d-5c7c-4890-b9d2-9085fa83dfcb";
     rdfs:label "Exchange Rate Specification";
@@ -933,7 +1058,8 @@
     dcterms:description "Exchange_Rate_Specification is structured value representing exchange rate.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Incoterms%23Exchange_Rate_Specification";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-11-20T08:24:59.201Z"^^xsd:dateTime.
 <https://example.com#0529e47e-32db-4ad0-ab2a-28a7ca04140c> rdf:type rdfs:Resource;
     dcterms:identifier "0529e47e-32db-4ad0-ab2a-28a7ca04140c";
     rdfs:label "In-Transit Inventory";
@@ -941,7 +1067,8 @@
     dcterms:description "Additional lobe: Planning";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23In_Transit_Inventory";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#f29a581e-c896-41e2-a7a5-39b8b69f2a2b> rdf:type rdfs:Resource;
     dcterms:identifier "f29a581e-c896-41e2-a7a5-39b8b69f2a2b";
     rdfs:label "Inventory";
@@ -949,7 +1076,8 @@
     dcterms:description "Additional lobe: Planning";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Inventory";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#b5e044b9-4532-4302-84a8-bac8324be02d> rdf:type rdfs:Resource;
     dcterms:identifier "b5e044b9-4532-4302-84a8-bac8324be02d";
     rdfs:label "Offer";
@@ -957,7 +1085,8 @@
     dcterms:description "An offer is to transfer some rights to an item or to provide a service.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Incoterms%23Offer";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-11-20T10:03:52.920Z"^^xsd:dateTime.
 <https://example.com#f722c3a8-a764-42f7-bcad-bfb78585cf2b> rdf:type rdfs:Resource;
     dcterms:identifier "f722c3a8-a764-42f7-bcad-bfb78585cf2b";
     rdfs:label "Open Order";
@@ -965,7 +1094,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Open_Order";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-11-20T10:04:08.775Z"^^xsd:dateTime.
 <https://example.com#5f8d7815-a548-47ad-ad6f-45a82797a8de> rdf:type rdfs:Resource;
     dcterms:identifier "5f8d7815-a548-47ad-ad6f-45a82797a8de";
     rdfs:label "Order Change Request";
@@ -973,7 +1103,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Order_Change_Request";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#1d13d30c-a345-4155-a7a6-277b9d369bb0> rdf:type rdfs:Resource;
     dcterms:identifier "1d13d30c-a345-4155-a7a6-277b9d369bb0";
     rdfs:label "Order Confirmation";
@@ -981,7 +1112,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Order_Confirmation";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#97ac0b0d-1bcb-427c-8a2c-cfbe7420c5b1> rdf:type rdfs:Resource;
     dcterms:identifier "97ac0b0d-1bcb-427c-8a2c-cfbe7420c5b1";
     rdfs:label "Order Position";
@@ -989,21 +1121,24 @@
     dcterms:description "An order position refers to a product specification, a product quantity, and a desired delivery date. Each order position has a status and belongs to an order.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Order_Position";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#3c485b0a-c556-40df-8666-3b59111f3745> rdf:type rdfs:Resource;
     dcterms:identifier "3c485b0a-c556-40df-8666-3b59111f3745";
     rdfs:label "Forecast Horizon";
     dcterms:description "The forecast horizon is the length of time into the future for which forecasts are to be prepared. These generally vary from short-term forecasting horizons (less than three months) to long-term horizons (more than two years).";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#b54440be-b53c-47fc-b4ab-2f69884eed6c> rdf:type rdfs:Resource;
     dcterms:identifier "b54440be-b53c-47fc-b4ab-2f69884eed6c";
     rdfs:label "Forecasting";
     dcterms:description "Forecasting is the prediction of values of a variable based on known past values of that variable or other related variables. Forecasts also may be based on expert judgments, which in turn are based on historical data and experience.";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#1f5ec71f-58fc-4f61-81e4-8cb2c84065c0> rdf:type rdfs:Resource;
     dcterms:identifier "1f5ec71f-58fc-4f61-81e4-8cb2c84065c0";
     rdfs:label "Triple Exponential Smoothing";
@@ -1011,7 +1146,8 @@
     dcterms:description "Holt-Winters’ exponential smoothing method : Winters extended Holt’s exponential smoothing method by including an extra equation that is used to adjust the forecast to reflect seasonality. This form of exponential smoothing can thus account for data series that include both trend and seasonal elements. It uses three smoothing parameters controlling the level, trend, and seasonality.";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#bfead7cc-2c48-4d04-9332-1203828391a7> rdf:type rdfs:Resource;
     dcterms:identifier "bfead7cc-2c48-4d04-9332-1203828391a7";
     rdfs:label "Double Exponential Smoothing";
@@ -1019,7 +1155,8 @@
     dcterms:description "Holt’s exponential smoothing method : Holt’s method is an extension of single exponential smoothing which allows for trends in the data. It uses two smoothing parameters, one of which is used to add a trend adjustment to the single smoothed value. It is sometimes also called double or linear exponential smoothing.";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#9f54cefc-33aa-4536-ac0d-45b32eb89615> rdf:type rdfs:Resource;
     dcterms:identifier "9f54cefc-33aa-4536-ac0d-45b32eb89615";
     rdfs:label "Mean Absolute Percentage Error";
@@ -1027,28 +1164,32 @@
     dcterms:description "The mean absolute percentage error is the mean or average of the sum of all of the percentage errors for a given data set taken without regard to sign. (That is, their absolute values are summed and the average computed.) It is one measure of accuracy commonly used in quantitative methods of forecasting.";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#8967e89b-837b-4809-83fc-4eaef28cd2e1> rdf:type rdfs:Resource;
     dcterms:identifier "8967e89b-837b-4809-83fc-4eaef28cd2e1";
     rdfs:label "Product Life Cycle";
     dcterms:description "The concept of the product life cycle is particularly useful in forecasting and analyzing historical data. It presumes that demand for a product follows an S-shaped curve growing slowly in the early stages, achieving rapid and sustained growth in the middle stages, and slowing again in the mature stage. See S-curve";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#4ed14982-7373-4df3-b716-994ed9bea09f> rdf:type rdfs:Resource;
     dcterms:identifier "4ed14982-7373-4df3-b716-994ed9bea09f";
     rdfs:label "S-Curve";
     dcterms:description "An S-curve is most frequently used to represent the product life cycle. Several different mathematical forms, such as the logistics curve, can be used to fit an S-curve to actual observed data";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2025-06-23T11:05:25.549Z"^^xsd:dateTime.
 <https://example.com#a46a45d9-bba5-4d06-bc96-3e0f9b8a6be4> rdf:type rdfs:Resource;
     dcterms:identifier "a46a45d9-bba5-4d06-bc96-3e0f9b8a6be4";
     rdfs:label "Turning Point";
     dcterms:description "Any time a data pattern changes direction it can be described as having reached a turning point. For seasonal patterns these turning points are usually very predictable and can be handled by many different forecasting methods because the length of a complete season remains constant. In many cyclical data patterns the length of the cycle varies as does its magnitude. Here the identification of turning points is a particularly difficult and important task";
     rdfs:seeAlso "N/A";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-11-20T10:06:57.106Z"^^xsd:dateTime.
 <https://example.com#002ccba2-0b71-4e81-81aa-96ed8c478bf7> rdf:type rdfs:Resource;
     dcterms:identifier "002ccba2-0b71-4e81-81aa-96ed8c478bf7";
     rdfs:label "Seller";
@@ -1056,7 +1197,8 @@
     dcterms:description "Seller is an entity which offers the services/goods.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Incoterms%23Seller";
     ex:status "draft";
-    dcterms:created "2024-08-01"^^xsd:date.
+    dcterms:created "2024-08-01"^^xsd:date;
+    dcterms:modified "2024-08-01T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#6d221526-27f3-4992-9518-48a616518907> rdf:type rdfs:Resource;
     dcterms:identifier "6d221526-27f3-4992-9518-48a616518907";
     rdfs:label "Order";
@@ -1064,7 +1206,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Order";
     ex:status "draft";
-    dcterms:created "2024-10-04"^^xsd:date.
+    dcterms:created "2024-10-04"^^xsd:date;
+    dcterms:modified "2024-10-04T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#46f069ab-34e9-48f4-919b-236f578a1375> rdf:type rdfs:Resource;
     dcterms:identifier "46f069ab-34e9-48f4-919b-236f578a1375";
     rdfs:label "Allocated Available To Promise";
@@ -1072,7 +1215,8 @@
     dcterms:description "AATP  is a data mart  that shows data from GOAL AATP process, combining data from 3 sources: SAP, I2 Applications and LogDB.\n\nThe universe provides access to the fact tables delivered by GOAL like Availability / Allocation Planning / Seller Mapping / Coverage.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Allocated_Available_To_Promise";
     ex:status "draft";
-    dcterms:created "2024-10-04"^^xsd:date.
+    dcterms:created "2024-10-04"^^xsd:date;
+    dcterms:modified "2024-10-04T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#7890d77b-1e10-4c81-888a-0622259f7ac8> rdf:type rdfs:Resource;
     dcterms:identifier "7890d77b-1e10-4c81-888a-0622259f7ac8";
     rdfs:label "Available To Promise";
@@ -1080,7 +1224,8 @@
     dcterms:description "Available to promise is a business function that provides a response to customer order inquiries, based on resource availability. It generates available quantities of the requested product, and delivery due dates.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Available_To_Promise";
     ex:status "draft";
-    dcterms:created "2024-10-04"^^xsd:date.
+    dcterms:created "2024-10-04"^^xsd:date;
+    dcterms:modified "2025-06-23T10:31:26.136Z"^^xsd:dateTime.
 <https://example.com#0668f213-be24-471a-8d85-ced08ac329d7> rdf:type rdfs:Resource;
     dcterms:identifier "0668f213-be24-471a-8d85-ced08ac329d7";
     rdfs:label "Capacity";
@@ -1088,7 +1233,8 @@
     dcterms:description "Additional lobe: Semiconductor Production";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Capacity";
     ex:status "draft";
-    dcterms:created "2024-10-04"^^xsd:date.
+    dcterms:created "2024-10-04"^^xsd:date;
+    dcterms:modified "2024-10-04T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#cbbe6d64-1fb0-435f-bcbd-7f4581a22539> rdf:type rdfs:Resource;
     dcterms:identifier "cbbe6d64-1fb0-435f-bcbd-7f4581a22539";
     rdfs:label "Customer";
@@ -1096,7 +1242,8 @@
     dcterms:description "A person or entity that buys goods or services  from a shop or business.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Customer";
     ex:status "draft";
-    dcterms:created "2024-10-04"^^xsd:date.
+    dcterms:created "2024-10-04"^^xsd:date;
+    dcterms:modified "2024-10-04T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#157b7dea-9db6-45fb-9932-706bf3d3847c> rdf:type rdfs:Resource;
     dcterms:identifier "157b7dea-9db6-45fb-9932-706bf3d3847c";
     rdfs:label "Open Order Book";
@@ -1104,7 +1251,8 @@
     dcterms:description "An order book is a business's list of open, unshipped, customer orders, normally time-phased and valued at actual individual order prices, that may include margin and profitability analysis.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Open_Order_Book";
     ex:status "draft";
-    dcterms:created "2024-10-04"^^xsd:date.
+    dcterms:created "2024-10-04"^^xsd:date;
+    dcterms:modified "2024-10-04T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#6312bdca-928c-48ac-84b3-10bf785693ef> rdf:type rdfs:Resource;
     dcterms:identifier "6312bdca-928c-48ac-84b3-10bf785693ef";
     rdfs:label "Order Line Item";
@@ -1112,7 +1260,8 @@
     dcterms:description "Every product on the order is referenced by a record that includes quantity and a reference to which order it belongs.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SCP%23Order_Line_Item";
     ex:status "draft";
-    dcterms:created "2024-10-04"^^xsd:date.
+    dcterms:created "2024-10-04"^^xsd:date;
+    dcterms:modified "2024-10-04T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#f8185dab-ab3a-4d20-a90e-7710647595d3> rdf:type rdfs:Resource;
     dcterms:identifier "f8185dab-ab3a-4d20-a90e-7710647595d3";
     rdfs:label "Performance Measure";
@@ -1120,7 +1269,8 @@
     dcterms:description "Each measure is defined by a calculation procedure. Performance measures can be blended using weights to express the importance of the different measures.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Performance_Measure";
     ex:status "draft";
-    dcterms:created "2024-10-04"^^xsd:date.
+    dcterms:created "2024-10-04"^^xsd:date;
+    dcterms:modified "2025-07-04T08:51:20.548Z"^^xsd:dateTime.
 <https://example.com#9e680292-5b22-43cf-bd02-51977746409b> rdf:type rdfs:Resource;
     dcterms:identifier "9e680292-5b22-43cf-bd02-51977746409b";
     rdfs:label "Plan";
@@ -1128,7 +1278,8 @@
     dcterms:description "A plan is an activity specification with an intended purpose. Planning is an activity with the purpose to determine a plan. Planning is associated with goals, in the present situation represented by objective functions to be optimized.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Plan";
     ex:status "draft";
-    dcterms:created "2024-10-04"^^xsd:date.
+    dcterms:created "2024-10-04"^^xsd:date;
+    dcterms:modified "2024-10-04T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#7daf8517-97e8-488c-87e5-ea13b7e28c10> rdf:type rdfs:Resource;
     dcterms:identifier "7daf8517-97e8-488c-87e5-ea13b7e28c10";
     rdfs:label "Plan";
@@ -1136,7 +1287,8 @@
     dcterms:description "A PLAN is an activity specification with an intended purpose.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Plan";
     ex:status "draft";
-    dcterms:created "2024-10-04"^^xsd:date.
+    dcterms:created "2024-10-04"^^xsd:date;
+    dcterms:modified "2024-10-04T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#8b1179fe-dc77-4967-b60e-f110069d85da> rdf:type rdfs:Resource;
     dcterms:identifier "8b1179fe-dc77-4967-b60e-f110069d85da";
     rdfs:label "Planing Purpose";
@@ -1144,7 +1296,8 @@
     dcterms:description "The PLANNING PURPOSE specifies the objectives of a certain planning activity. It is given by a set of performance measures that are related to a set of PLANNING OBJECTS.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Planing_Purpose";
     ex:status "draft";
-    dcterms:created "2024-10-04"^^xsd:date.
+    dcterms:created "2024-10-04"^^xsd:date;
+    dcterms:modified "2024-10-04T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#f4d05861-1307-4305-8917-14353f96d04e> rdf:type rdfs:Resource;
     dcterms:identifier "f4d05861-1307-4305-8917-14353f96d04e";
     rdfs:label "Product Aggregate";
@@ -1152,14 +1305,16 @@
     dcterms:description "A PRODUCT AGGREGATE combines individual products into a few logical products groups. This results in a reduction of complexity, which enables a better overview.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Product_Aggregate";
     ex:status "draft";
-    dcterms:created "2024-10-04"^^xsd:date.
+    dcterms:created "2024-10-04"^^xsd:date;
+    dcterms:modified "2024-10-04T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#94d6b5ce-da43-4d58-8a41-89d07c5d40a2> rdf:type rdfs:Resource;
     dcterms:identifier "94d6b5ce-da43-4d58-8a41-89d07c5d40a2";
     rdfs:label "Product Hierarchy";
     dcterms:description "A PRODUCT HIERARCHY characterizes the top-down and bottom-up relationship between different product aggregates. It organizes the product aggregates according to defined criteria. A product aggregate is used to group different products based on certain criteria. The grouping criteria depend on the planning purpose (e.g. controlling, production). It is a certain view on a set of products.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Product_Hierarchy";
     ex:status "draft";
-    dcterms:created "2024-10-10"^^xsd:date.
+    dcterms:created "2024-10-10"^^xsd:date;
+    dcterms:modified "2024-10-10T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#1279b8e9-5f02-4e14-a7c2-46e05595259b> rdf:type rdfs:Resource;
     dcterms:identifier "1279b8e9-5f02-4e14-a7c2-46e05595259b";
     rdfs:label "Allocated Available To Promise";
@@ -1167,7 +1322,8 @@
     dcterms:description "When scarce ATP quantities are allocated to different customer classes or customers, the resulting supply reservations are called allocated ATP (AATP) quantities.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Allocated_Available_To_Promise";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#3fe64d88-12bc-43ad-9d62-9a0338bbe3bb> rdf:type rdfs:Resource;
     dcterms:identifier "3fe64d88-12bc-43ad-9d62-9a0338bbe3bb";
     rdfs:label "Available To Promise";
@@ -1175,7 +1331,8 @@
     dcterms:description "The part of the inventory and projected supply that can be used to fulfill customer orders is called ATP.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Available_To_Promise";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#d33f3387-457a-43a1-a2f1-8879e3d5c7a7> rdf:type rdfs:Resource;
     dcterms:identifier "d33f3387-457a-43a1-a2f1-8879e3d5c7a7";
     rdfs:label "Customer";
@@ -1183,7 +1340,8 @@
     dcterms:description "A customer can place orders. He raises a demand for a specific product or service. Internal and external customer demand can be distinguished.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Customer";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#de8979d5-b927-4538-b800-c820792c805c> rdf:type rdfs:Resource;
     dcterms:identifier "de8979d5-b927-4538-b800-c820792c805c";
     rdfs:label "Customer";
@@ -1191,7 +1349,8 @@
     dcterms:description "Customer is a person or organization that places order or pay the invoice.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Incoterms%23Customer";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#4e1b7970-cfb8-4fb8-bf11-c10ca059f418> rdf:type rdfs:Resource;
     dcterms:identifier "4e1b7970-cfb8-4fb8-bf11-c10ca059f418";
     rdfs:label "Customer";
@@ -1199,7 +1358,8 @@
     dcterms:description "A customer is an business that purchases another company's goods or services.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Customer";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#8bc1bda0-6a02-48c8-a5c0-b04bd30b7694> rdf:type rdfs:Resource;
     dcterms:identifier "8bc1bda0-6a02-48c8-a5c0-b04bd30b7694";
     rdfs:label "Demand";
@@ -1207,7 +1367,8 @@
     dcterms:description "Demand is a production request for a specific product or service that can have different triggers. Either demand exists explicitly in form of customer orders or implicitly as expected customer need that have to be fulfilled by the semiconductor supply chain.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Demand";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2025-06-23T10:43:30.940Z"^^xsd:dateTime.
 <https://example.com#214b7225-5bb1-4956-ab58-f63175c4446b> rdf:type rdfs:Resource;
     dcterms:identifier "214b7225-5bb1-4956-ab58-f63175c4446b";
     rdfs:label "Demand";
@@ -1215,7 +1376,8 @@
     dcterms:description "Additional lobe: Planning";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Demand";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#95dbd732-5afc-4add-b6cd-620f0e301286> rdf:type rdfs:Resource;
     dcterms:identifier "95dbd732-5afc-4add-b6cd-620f0e301286";
     rdfs:label "Demand Class";
@@ -1223,7 +1385,8 @@
     dcterms:description "This concept is used for dividing the total forecast for a given product into several priority classes.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Demand_Class";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#66a54f5f-b44b-4b99-a3c4-28ee8bf3f7d4> rdf:type rdfs:Resource;
     dcterms:identifier "66a54f5f-b44b-4b99-a3c4-28ee8bf3f7d4";
     rdfs:label "Demand Fulfillement";
@@ -1231,7 +1394,8 @@
     dcterms:description "The process of meeting a customer’s demand for product or services by fulfilling their request.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Demand_Fulfillement";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2025-06-23T10:45:41.605Z"^^xsd:dateTime.
 <https://example.com#4da75d3b-5cab-46a0-a07d-c9a62cfcf6ae> rdf:type rdfs:Resource;
     dcterms:identifier "4da75d3b-5cab-46a0-a07d-c9a62cfcf6ae";
     rdfs:label "Demand Snapshot";
@@ -1239,7 +1403,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-GDM%23Demand_Snapshot";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2025-06-23T10:49:49.145Z"^^xsd:dateTime.
 <https://example.com#98e1dada-debf-4b11-9870-f4a00d028d73> rdf:type rdfs:Resource;
     dcterms:identifier "98e1dada-debf-4b11-9870-f4a00d028d73";
     rdfs:label "Open Order Book";
@@ -1247,7 +1412,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Open_Order_Book";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#196e96c9-85a6-45fc-bf54-6593c5bba0b6> rdf:type rdfs:Resource;
     dcterms:identifier "196e96c9-85a6-45fc-bf54-6593c5bba0b6";
     rdfs:label "Order";
@@ -1255,7 +1421,8 @@
     dcterms:description "An order contains at least one order position. An order has an order type and is associated to demand";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Order";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#f9048421-8000-4c00-85d7-0fbf5a64d737> rdf:type rdfs:Resource;
     dcterms:identifier "f9048421-8000-4c00-85d7-0fbf5a64d737";
     rdfs:label "Order";
@@ -1263,7 +1430,8 @@
     dcterms:description "Additional lobe: Planning";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Order";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#e76552e5-7c2c-474c-8b42-f702635046d8> rdf:type rdfs:Resource;
     dcterms:identifier "e76552e5-7c2c-474c-8b42-f702635046d8";
     rdfs:label "Order Line Item";
@@ -1271,7 +1439,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Order_Line_Item";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#00828d2b-55c9-4046-8556-5d22873f1e0c> rdf:type rdfs:Resource;
     dcterms:identifier "00828d2b-55c9-4046-8556-5d22873f1e0c";
     rdfs:label "Owner";
@@ -1279,7 +1448,8 @@
     dcterms:description "Additional lobe: Planning";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-Planning%23Owner";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#dcda03b6-c4d2-4903-88a7-cab4819107b1> rdf:type rdfs:Resource;
     dcterms:identifier "dcda03b6-c4d2-4903-88a7-cab4819107b1";
     rdfs:label "Supplier";
@@ -1287,7 +1457,8 @@
     dcterms:description "A Supplier fufills a demand for a specific product or service.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Supplier";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#864a88de-dfc7-4313-af47-bba1c6b938a2> rdf:type rdfs:Resource;
     dcterms:identifier "864a88de-dfc7-4313-af47-bba1c6b938a2";
     rdfs:label "Supplier";
@@ -1295,7 +1466,8 @@
     dcterms:description "Organization that provides something needed such as a product or service.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Supplier";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#55582b69-476b-47c7-b73f-615e01aaa2b1> rdf:type rdfs:Resource;
     dcterms:identifier "55582b69-476b-47c7-b73f-615e01aaa2b1";
     rdfs:label "Supply";
@@ -1303,7 +1475,8 @@
     dcterms:description "This is the total amount of specific products that is available to customers. Supply has the dimensions quantity, time, location, product, including aggregation of all dimensions. Supply is defined as inventory or plan replenishment.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Supply";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#dcc56d27-3cfe-4bb2-8155-e6a64a95f9c1> rdf:type rdfs:Resource;
     dcterms:identifier "dcc56d27-3cfe-4bb2-8155-e6a64a95f9c1";
     rdfs:label "Supply";
@@ -1311,7 +1484,8 @@
     dcterms:description "The amount of goods that is available for use.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23Supply";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#74d20cab-563a-4e9a-882b-a08c3bda856b> rdf:type rdfs:Resource;
     dcterms:identifier "74d20cab-563a-4e9a-882b-a08c3bda856b";
     rdfs:label "Supply Chain";
@@ -1319,7 +1493,8 @@
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Supply_Chain";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2025-06-23T11:09:30.563Z"^^xsd:dateTime.
 <https://example.com#d3da1b03-7392-4203-be3d-3a3173e6857e> rdf:type rdfs:Resource;
     dcterms:identifier "d3da1b03-7392-4203-be3d-3a3173e6857e";
     rdfs:label "User Action";
@@ -1327,84 +1502,96 @@
     dcterms:description "Activity taken by user";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-OM%23User_Action";
     ex:status "draft";
-    dcterms:created "2024-10-18"^^xsd:date.
+    dcterms:created "2024-10-18"^^xsd:date;
+    dcterms:modified "2024-10-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#4d933028-c44a-4557-aac5-528bd15e1ab0> rdf:type rdfs:Resource;
     dcterms:identifier "4d933028-c44a-4557-aac5-528bd15e1ab0";
     rdfs:label "Partner";
     dcterms:description "Company or institute that has signed the SC4EU consortium agreement";
     rdfs:seeAlso "Participant";
     ex:status "draft";
-    dcterms:created "2024-11-20"^^xsd:date.
+    dcterms:created "2024-11-20"^^xsd:date;
+    dcterms:modified "2025-06-23T12:39:15.932Z"^^xsd:dateTime.
 <https://example.com#04ebacdf-8b1c-46df-81fd-1665df6a7594> rdf:type rdfs:Resource;
     dcterms:identifier "04ebacdf-8b1c-46df-81fd-1665df6a7594";
     rdfs:label "Participant";
     dcterms:description "Company that fills in the SC4EU survey";
     rdfs:seeAlso "Partner";
     ex:status "draft";
-    dcterms:created "2024-11-20"^^xsd:date.
+    dcterms:created "2024-11-20"^^xsd:date;
+    dcterms:modified "2024-11-20T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#cf5404ed-9046-47de-a045-53daa6e3adba> rdf:type rdfs:Resource;
     dcterms:identifier "cf5404ed-9046-47de-a045-53daa6e3adba";
     rdfs:label "Reactive Stocking";
     dcterms:description "Response to a change in demand. Inventory is adapted in line with Desired Inventory Coverage.";
     rdfs:seeAlso "Active destocking";
     ex:status "draft";
-    dcterms:created "2024-11-20"^^xsd:date.
+    dcterms:created "2024-11-20"^^xsd:date;
+    dcterms:modified "2024-11-20T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#07327ac9-a32d-4e7f-8fbd-3197ad96d4e1> rdf:type rdfs:Resource;
     dcterms:identifier "07327ac9-a32d-4e7f-8fbd-3197ad96d4e1";
     rdfs:label "Active destocking";
     skos:altLabel "Reactive stocking";
     dcterms:description "A conscious management decision to reduce the Desired Inventory Coverage. This happened when interbank interest rates peaked after the unexpected bankruptcy of Lehman Brothers (a bank) on 15 September 2008. The result was a global wave of temporary inventory reduction.";
     ex:status "draft";
-    dcterms:created "2024-11-20"^^xsd:date.
+    dcterms:created "2024-11-20"^^xsd:date;
+    dcterms:modified "2025-04-11T06:00:36.242Z"^^xsd:dateTime.
 <https://example.com#3f3b5242-0011-4422-b9cf-02deba5aba3a> rdf:type rdfs:Resource;
     dcterms:identifier "3f3b5242-0011-4422-b9cf-02deba5aba3a";
     rdfs:label "Pipeline";
     dcterms:description "A stock of raw material orders that have been sent out, but for which the goods have not yet been delivered.";
     rdfs:seeAlso "Underestimation";
     ex:status "draft";
-    dcterms:created "2024-11-20"^^xsd:date.
+    dcterms:created "2024-11-20"^^xsd:date;
+    dcterms:modified "2024-11-20T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#71eba900-3be9-4eaf-9999-891ea06d1da5> rdf:type rdfs:Resource;
     dcterms:identifier "71eba900-3be9-4eaf-9999-891ea06d1da5";
     rdfs:label "Underestimation";
     dcterms:description "Thinking that something is smaller than it actually is. Most companies underestimate their Pipeline and do not take it fully into account when determining how much orders to send out.";
     rdfs:seeAlso "Pipeline";
     ex:status "draft";
-    dcterms:created "2024-11-20"^^xsd:date.
+    dcterms:created "2024-11-20"^^xsd:date;
+    dcterms:modified "2024-11-20T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#b798765f-ace3-497d-a0ba-3b8619d0983f> rdf:type rdfs:Resource;
     dcterms:identifier "b798765f-ace3-497d-a0ba-3b8619d0983f";
     rdfs:label "MPC Management Server";
     dcterms:description "The Multi-Party Computation Management Server orchestrates MPC computations by delegating them to a set of MPC Computation Servers. The MPC Management Server furthermore provides frontends for Survey Participants, Administrators, and Analysts.";
     rdfs:seeAlso "WP6 material";
     ex:status "draft";
-    dcterms:created "2024-12-18"^^xsd:date.
+    dcterms:created "2024-12-18"^^xsd:date;
+    dcterms:modified "2024-12-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#fcb48ce8-6255-4bf0-8032-d794bac11159> rdf:type rdfs:Resource;
     dcterms:identifier "fcb48ce8-6255-4bf0-8032-d794bac11159";
     rdfs:label "MPC Computation Server";
     dcterms:description "The MPC Computation Server performs actual computations in MPC by connecting to two other MPC Computation Servers. The program to be executed is provided by the MPC Management Server.";
     rdfs:seeAlso "WP6 material";
     ex:status "draft";
-    dcterms:created "2024-12-18"^^xsd:date.
+    dcterms:created "2024-12-18"^^xsd:date;
+    dcterms:modified "2024-12-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#d13dd919-de64-4263-bd38-f75d96f6239f> rdf:type rdfs:Resource;
     dcterms:identifier "d13dd919-de64-4263-bd38-f75d96f6239f";
     rdfs:label "MPC Survey Framework";
     dcterms:description "A set of applications for performing computations in MPC, collecting answers from Survey Participants, and maintaining the MPC Survey Framework.  ";
     rdfs:seeAlso "WP6 material";
     ex:status "draft";
-    dcterms:created "2024-12-18"^^xsd:date.
+    dcterms:created "2024-12-18"^^xsd:date;
+    dcterms:modified "2024-12-18T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#06a40a37-546d-4e63-bfee-975e62cde8d0> rdf:type rdfs:Resource;
     dcterms:identifier "06a40a37-546d-4e63-bfee-975e62cde8d0";
     rdfs:label "lithography";
     dcterms:description "Any synthesis technique involving the transfer of a pattern to a material (a 'resist') by selective exposure to a radiation source (e.g. light or X-rays) or to a beam of charged particles. Upon irradiation, the material experiences a change in its physical properties. Excess material is then removed, by a liquid 'developer' or an etching process.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/chmo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCHMO_0001388";
     ex:status "draft";
-    dcterms:created "2025-02-10"^^xsd:date.
+    dcterms:created "2025-02-10"^^xsd:date;
+    dcterms:modified "2025-02-10T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#9d5127e5-88ec-4df3-9d31-0d93b6711860> rdf:type rdfs:Resource;
     dcterms:identifier "9d5127e5-88ec-4df3-9d31-0d93b6711860";
     rdfs:label "Wafer Fabrication";
     skos:altLabel "Wafer Production", "Wafer Manufacturing";
     dcterms:description "The process of creating semiconductor wafers through various stages, including crystal growth, slicing, and polishing. Generally performed in a Front End wafer fab.";
     ex:status "draft";
-    dcterms:created "2025-02-10"^^xsd:date.
+    dcterms:created "2025-02-10"^^xsd:date;
+    dcterms:modified "2025-06-23T10:57:07.987Z"^^xsd:dateTime.
 <https://example.com#80321df7-2b8b-4636-9e5a-cdc45e935263> rdf:type rdfs:Resource;
     dcterms:identifier "80321df7-2b8b-4636-9e5a-cdc45e935263";
     rdfs:label "Lithography";
@@ -1412,54 +1599,62 @@
     dcterms:description "The lithography process is the key process in frontend. This consists of the following steps: a photo resisting layer is spun on a wafer, then exposed through the mask, then developed, then showing the effect on the open places, and then final deletion of the photo resisting material leaves only the remaining structure on the water. after some time for deposition, these steps are repeated up to 35 times.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SO%23Lithography";
     ex:status "draft";
-    dcterms:created "2025-02-10"^^xsd:date.
+    dcterms:created "2025-02-10"^^xsd:date;
+    dcterms:modified "2025-02-10T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#34e92c1c-7f7d-49ed-99fc-195e187f3c9c> rdf:type rdfs:Resource;
     dcterms:identifier "34e92c1c-7f7d-49ed-99fc-195e187f3c9c";
     rdfs:label "Lot";
     dcterms:description "The Lot represents manufacturing unit (e.g. in the semicondutor industry in Frontend this often consists of 25 or 50 wafers).";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SO%23Lot";
     ex:status "draft";
-    dcterms:created "2025-04-23"^^xsd:date.
+    dcterms:created "2025-04-23"^^xsd:date;
+    dcterms:modified "2025-04-23T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#7c211ee2-4ec3-4bc9-9286-8c657a099e27> rdf:type rdfs:Resource;
     dcterms:identifier "7c211ee2-4ec3-4bc9-9286-8c657a099e27";
     rdfs:label "Hot";
     dcterms:description "These lots are processed after a certain maximum waiting time which is shorter than the maximum waiting time of standard lots. In general, for all classes, if there is more than one product type waiting.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SO%23Hot";
     ex:status "draft";
-    dcterms:created "2025-04-23"^^xsd:date.
+    dcterms:created "2025-04-23"^^xsd:date;
+    dcterms:modified "2025-04-23T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#701d4e26-20a8-46f6-bafb-7b7a11e3b91f> rdf:type rdfs:Resource;
     dcterms:identifier "701d4e26-20a8-46f6-bafb-7b7a11e3b91f";
     rdfs:label "Priority Class";
     dcterms:description "Each lot is characterized by a product type and a priority class. Example list of potential priority classes : low, standard, medium, hot, super hot.";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-SO%23Priority_Class";
     ex:status "draft";
-    dcterms:created "2025-04-23"^^xsd:date.
+    dcterms:created "2025-04-23"^^xsd:date;
+    dcterms:modified "2025-04-23T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#14338e58-88a2-4ba3-b221-ae1b3e29b3b1> rdf:type rdfs:Resource;
     dcterms:identifier "14338e58-88a2-4ba3-b221-ae1b3e29b3b1";
     rdfs:label "Cycle time";
     dcterms:description "In semiconductor manufacturing, corresponds to the delay time between the release of the lot in a wafer fab and its completion, including or not back end stages.";
     ex:status "draft";
-    dcterms:created "2025-04-23"^^xsd:date.
+    dcterms:created "2025-04-23"^^xsd:date;
+    dcterms:modified "2025-04-23T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#93ec6f6b-e777-4f34-846c-ea57a9ae0967> rdf:type rdfs:Resource;
     dcterms:identifier "93ec6f6b-e777-4f34-846c-ea57a9ae0967";
     rdfs:label "Supply Chain";
     dcterms:description "Not Available";
     rdfs:seeAlso "url:https://terminology.tib.eu/ts/ontologies/dr/terms?iri=http%3A%2F%2Fwww.w3id.org%2Fecsel-dr-DF%23Supply_Chain";
     ex:status "draft";
-    dcterms:created "2025-05-28"^^xsd:date.
+    dcterms:created "2025-05-28"^^xsd:date;
+    dcterms:modified "2025-05-28T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#1a2b8640-1c0c-4a65-9414-21b67a2abc0e> rdf:type rdfs:Resource;
     dcterms:identifier "1a2b8640-1c0c-4a65-9414-21b67a2abc0e";
     rdfs:label "Test";
     dcterms:description "just a test";
     ex:status "draft";
-    dcterms:created "2025-06-03"^^xsd:date.
+    dcterms:created "2025-06-03"^^xsd:date;
+    dcterms:modified "2025-06-04T10:51:53.757Z"^^xsd:dateTime.
 <https://example.com#814868c5-de51-4166-a338-8e64be239c82> rdf:type rdfs:Resource;
     dcterms:identifier "814868c5-de51-4166-a338-8e64be239c82";
     rdfs:label "inventory";
     dcterms:description "Semi-finished goods are products that have undergone some processing but require further manufacturing or assembly before they are ready for sale as finished goods.";
     rdfs:seeAlso "Finished goods";
     ex:status "draft";
-    dcterms:created "2025-06-11"^^xsd:date.
+    dcterms:created "2025-06-11"^^xsd:date;
+    dcterms:modified "2025-06-11T10:00:00.000Z"^^xsd:dateTime.
 <https://example.com#bdff7487-8f92-4747-9aef-597213c091be> rdf:type rdfs:Resource;
     dcterms:identifier "bdff7487-8f92-4747-9aef-597213c091be";
     rdfs:label "Demand Priority";


### PR DESCRIPTION
Have added new _dcterms:modified_ to all terms that didn't have it prior. Terms that have any comments has the _dctems:modified_ equal to the last comment date time; terms that have none - have _dcterms:modified_ equal to the _dcterms:created_ (created date) with default time - 10:00:000  